### PR TITLE
Fix deconv and force compile model

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2811,9 +2811,11 @@ def pool2d(x, pool_size, strides=(1, 1),
     # Returns
         A tensor, result of 2D pooling.
     """
+    x = _preprocess_conv2d_input(x, dim_ordering)
     s = mx.sym.Pooling(data=x.symbol, kernel=pool_size, pool_type=pool_mode, pooling_convention=border_mode,
                        stride=strides)
-    return KerasSymbol(s)
+    out = _postprocess_conv2d_output(KerasSymbol(s), dim_ordering)
+    return out
 
 
 @keras_symbol_child

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2656,6 +2656,14 @@ def _preprocess_border_mode(border_mode, input_shape, kernel, strides, dilation)
         raise ValueError('Invalid border mode:', border_mode)
     return padding, np.any(is_slice), out_size
 
+def _preprocess_deconv2d_output(output_shape, dim_ordering):
+    if dim_ordering == 'default':
+        output_shape = image_dim_ordering()
+    if dim_ordering == 'th':
+        output_shape = output_shape[2:]
+    if dim_ordering == 'tf':
+        output_shape = output_shape[1:3]
+    return output_shape
 
 @keras_symbol_child
 def conv1d(x, kernel, stride=1, border_mode='valid',
@@ -2726,6 +2734,7 @@ def deconv2d(x, kernel, output_shape, strides=(1, 1),
         A tensor, result of transposed 2D convolution.
     """
     layout_kernel, nb_filter = _layout_kernel2(dim_ordering, kernel.shape)
+    output_shape = _preprocess_deconv2d_output(output_shape, dim_ordering)
     s = mx.sym.Deconvolution(data=x.symbol, name=kernel.name, kernel=layout_kernel, stride=strides,
                              num_filter=nb_filter, weight=kernel.symbol, no_bias=True, target_shape=output_shape)
     return KerasSymbol(s)

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -1884,6 +1884,8 @@ if K.backend() == 'mxnet':
             K.set_model(self)
 
         def _adjust_module(self, inputs, phase):
+            if not hasattr(self, '_num_data'):
+                raise RuntimeError('You must compile your model before using it.')
             if self._num_data + self._num_label == len(inputs) - 1:
                 inputs = inputs[:-1]
             elif self._num_data == len(inputs) - 1:


### PR DESCRIPTION
1. Chop output_shape to (y, x) format to pass to target_shape.
2. Force model compiling before training, testing and predicting.
3. Fix pool2d when dim_ordering is 'tf'.

TODO:
Current mxnet deconvolution operator only accepts target_shape which is no greater than s*(i - 1) + k, where s is strides, i is input size and k is kernel size. Maybe in the future we need to add support for oversized target_shape.